### PR TITLE
Fixed incorrect return of validation_resuts key on the domain validation response

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2018 SendGrid, Inc.
+Copyright (c) 2016-2019 SendGrid, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/oai.json
+++ b/oai.json
@@ -21576,7 +21576,7 @@
                                     "type": "boolean",
                                     "description": "Indicates if this is a valid whitelabel."
                                 },
-                                "validation_resuts": {
+                                "validation_results": {
                                     "type": "object",
                                     "description": "The individual DNS records that are checked when validating, including the reason for any invalid DNS records.",
                                     "properties": {
@@ -21641,7 +21641,7 @@
                             "application/json": {
                                 "id": 1,
                                 "valid": true,
-                                "validation_resuts": {
+                                "validation_results": {
                                     "mail_cname": {
                                         "valid": false,
                                         "reason": "Expected your MX record to be \"mx.sendgrid.net\" but found \"example.com\"."

--- a/oai.yaml
+++ b/oai.yaml
@@ -15120,7 +15120,7 @@ paths:
               valid:
                 type: boolean
                 description: Indicates if this is a valid whitelabel.
-              validation_resuts:
+              validation_results:
                 type: object
                 description: 'The individual DNS records that are checked when validating, including the reason for any invalid DNS records.'
                 properties:
@@ -15165,7 +15165,7 @@ paths:
             application/json:
               id: 1
               valid: true
-              validation_resuts:
+              validation_results:
                 mail_cname:
                   valid: false
                   reason: Expected your MX record to be "mx.sendgrid.net" but found "example.com".

--- a/oai_stoplight.json
+++ b/oai_stoplight.json
@@ -24055,7 +24055,7 @@
                                     "type": "boolean",
                                     "description": "Indicates if this is a valid whitelabel."
                                 },
-                                "validation_resuts": {
+                                "validation_results": {
                                     "type": "object",
                                     "description": "The individual DNS records that are checked when validating, including the reason for any invalid DNS records.",
                                     "properties": {
@@ -24120,7 +24120,7 @@
                             "application/json": {
                                 "id": 1,
                                 "valid": true,
-                                "validation_resuts": {
+                                "validation_results": {
                                     "mail_cname": {
                                         "valid": false,
                                         "reason": "Expected your MX record to be \"mx.sendgrid.net\" but found \"example.com\"."


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 

Closes #2
-->
# Fixes #67 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Corrects the `validation_results` returned on domain validation

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
