### PR TITLE
fix: use last working version of OAI to run prism

### DIFF
--- a/prism/prism.sh
+++ b/prism/prism.sh
@@ -3,6 +3,7 @@ set -e
 
 rm -rf prism && mkdir -p prism && cd prism
 git clone --depth 1 https://github.com/sendgrid/sendgrid-oai .
+git checkout eb7a825bf06dfec7da2622735c5334c0d35da9fa
 cd prism
 
 docker-compose build --parallel


### PR DESCRIPTION
Use the last working commit to run prism tests for the helper libraries.
Jira: https://issues.corp.twilio.com/browse/DI-1501