### PR TITLE
chore: update prism for GitHub Actions

### DIFF
--- a/prism/Dockerfile
+++ b/prism/Dockerfile
@@ -1,8 +1,9 @@
 FROM node
 
 ADD https://github.com/stoplightio/prism/releases/download/v0.6.21/prism_linux_amd64 prism
+ADD https://raw.githubusercontent.com/sendgrid/sendgrid-oai/eb7a825bf06dfec7da2622735c5334c0d35da9fa/oai_stoplight.json oai_stoplight.json
 RUN chmod +x prism
 
 EXPOSE 4010
 
-CMD ["./prism", "run", "--port", "4010", "--mock", "--list", "--spec", "https://raw.githubusercontent.com/sendgrid/sendgrid-oai/eb7a825bf06dfec7da2622735c5334c0d35da9fa/oai_stoplight.json"]
+CMD ["./prism", "run", "--port", "4010", "--mock", "--list", "--spec", "oai_stoplight.json"]

--- a/prism/docker-compose.yml
+++ b/prism/docker-compose.yml
@@ -14,13 +14,9 @@ services:
       default:
         aliases:
           - api.sendgrid.com
-    restart: always
     depends_on:
       - prism
     volumes:
       - ./nginx:/etc/nginx
-    ports:
-      - 80:80
-      - 443:443
   prism:
     build: ./

--- a/prism/docker-compose.yml
+++ b/prism/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       default:
         aliases:
           - api.sendgrid.com
+    restart: always
     depends_on:
       - prism
     volumes:

--- a/prism/docker-compose.yml
+++ b/prism/docker-compose.yml
@@ -18,5 +18,8 @@ services:
       - prism
     volumes:
       - ./nginx:/etc/nginx
+    ports:
+      - 80:80
+      - 443:443
   prism:
     build: ./

--- a/prism/nginx/nginx.conf
+++ b/prism/nginx/nginx.conf
@@ -7,12 +7,7 @@ http {
 
     location / {
       proxy_pass http://prism:4010;
-      proxy_ignore_client_abort on;
     }
-
-    proxy_read_timeout 300;
-    proxy_connect_timeout 300;
-    proxy_send_timeout 300;
   }
 
   client_max_body_size 0;

--- a/prism/nginx/nginx.conf
+++ b/prism/nginx/nginx.conf
@@ -2,9 +2,6 @@ events {}
 http {
   proxy_buffering off;
   server {
-    listen 80;
-    listen 443 ssl;
-
     ssl_certificate /etc/nginx/cert.crt;
     ssl_certificate_key /etc/nginx/cert.key;
 

--- a/prism/nginx/nginx.conf
+++ b/prism/nginx/nginx.conf
@@ -1,5 +1,5 @@
 events {}
-error_log /dev/stdout info;
+error_log /dev/stdout debug;
 http {
   access_log /dev/stdout;
   server {

--- a/prism/nginx/nginx.conf
+++ b/prism/nginx/nginx.conf
@@ -1,5 +1,7 @@
 events {}
+error_log /dev/stdout info;
 http {
+  access_log /dev/stdout;
   server {
     listen 80;
     listen 443 ssl;

--- a/prism/nginx/nginx.conf
+++ b/prism/nginx/nginx.conf
@@ -7,6 +7,7 @@ http {
 
     location / {
       proxy_pass http://prism:4010;
+      proxy_ignore_client_abort on;
     }
   }
 

--- a/prism/nginx/nginx.conf
+++ b/prism/nginx/nginx.conf
@@ -12,6 +12,10 @@ http {
     location / {
       proxy_pass http://prism:4010;
     }
+
+    proxy_read_timeout 300;
+    proxy_connect_timeout 300;
+    proxy_send_timeout 300;
   }
 
   client_max_body_size 0;

--- a/prism/prism.sh
+++ b/prism/prism.sh
@@ -8,7 +8,7 @@ cd prism
 docker-compose build --parallel
 
 if [ -z "$command" ]; then
-  docker-compose up --force-recreate
+  docker-compose up --force-recreate --abort-on-container-exit
 else
   docker-compose run helper-runner "$command"
   docker-compose down

--- a/prism/prism.sh
+++ b/prism/prism.sh
@@ -2,7 +2,7 @@
 set -e
 
 rm -rf prism && mkdir -p prism && cd prism
-git clone --depth 1 https://github.com/sendgrid/sendgrid-oai .
+git clone https://github.com/sendgrid/sendgrid-oai .
 git checkout gh-actions
 cd prism
 

--- a/prism/prism.sh
+++ b/prism/prism.sh
@@ -2,7 +2,8 @@
 set -e
 
 rm -rf prism && mkdir -p prism && cd prism
-git clone --branch gh-actions --depth 1 https://github.com/sendgrid/sendgrid-oai .
+git clone --depth 1 https://github.com/sendgrid/sendgrid-oai .
+git checkout gh-actions
 cd prism
 
 docker-compose build --parallel

--- a/prism/prism.sh
+++ b/prism/prism.sh
@@ -2,8 +2,7 @@
 set -e
 
 rm -rf prism && mkdir -p prism && cd prism
-git clone https://github.com/sendgrid/sendgrid-oai .
-git checkout gh-actions
+git clone --branch gh-actions https://github.com/sendgrid/sendgrid-oai .
 cd prism
 
 docker-compose build --parallel

--- a/prism/prism.sh
+++ b/prism/prism.sh
@@ -2,7 +2,7 @@
 set -e
 
 rm -rf prism && mkdir -p prism && cd prism
-git clone --branch prism-updated https://github.com/sendgrid/sendgrid-oai .
+git clone --depth 1 https://github.com/sendgrid/sendgrid-oai .
 cd prism
 
 docker-compose build --parallel

--- a/prism/prism.sh
+++ b/prism/prism.sh
@@ -8,7 +8,7 @@ cd prism
 docker-compose build --parallel
 
 if [ -z "$command" ]; then
-  docker-compose up --force-recreate --abort-on-container-exit
+  docker-compose up --force-recreate
 else
   docker-compose run helper-runner "$command"
   docker-compose down

--- a/prism/prism.sh
+++ b/prism/prism.sh
@@ -2,7 +2,7 @@
 set -e
 
 rm -rf prism && mkdir -p prism && cd prism
-git clone --depth 1 https://github.com/sendgrid/sendgrid-oai .
+git clone --branch gh-actions --depth 1 https://github.com/sendgrid/sendgrid-oai .
 cd prism
 
 docker-compose build --parallel

--- a/prism/prism.sh
+++ b/prism/prism.sh
@@ -8,7 +8,7 @@ cd prism
 docker-compose build --parallel
 
 if [ -z "$command" ]; then
-  docker-compose up --force-recreate --abort-on-container-exit
+  docker-compose up --force-recreate --abort-on-container-exit --remove-orphans
 else
   docker-compose run helper-runner "$command"
   docker-compose down


### PR DESCRIPTION
Tested in [this workflow](https://github.com/sendgrid/sendgrid-csharp/runs/4255761065?check_suite_focus=true)

Older version of prism caused nginx service to be unable to run in GitHub Actions hosted runners when performing integration tests. These changes introduce updates that allow integration tests to run successfully in downstream helper libraries. 