### PR TITLE
Fix: Remove trailing whitespace from "updated_at " to make it "updated_at"

### DIFF
--- a/oai.json
+++ b/oai.json
@@ -23222,7 +23222,7 @@
                                         "id": "fae7c985-eb92-4b47-9987-28ec29dbc698",
                                         "name": "example_name",
                                         "generation": "legacy",
-                                        "updated_at ": "2020-11-12 12:00:09",
+                                        "updated_at": "2020-11-12 12:00:09",
                                         "versions": []
                                     }
                                 ],
@@ -23315,7 +23315,7 @@
                                 "id": "733ba07f-ead1-41fc-933a-3976baa2371",
                                 "name": "example_name",
                                 "generation": "dynamic",
-                                "updated_at ": "2019-03-13T11:52:41.009Z",
+                                "updated_at": "2019-03-13T11:52:41.009Z",
                                 "versions": []
                             }
                         }
@@ -23350,7 +23350,7 @@
                                 "id": "40da60e6-66f3-4223-9406-ba58b7f55a62",
                                 "name": "Duis in dolor",
                                 "generation": "legacy",
-                                "updated_at ": "2020-12-12 58:26:65",
+                                "updated_at": "2020-12-12 58:26:65",
                                 "versions": []
                             }
                         }
@@ -32576,7 +32576,7 @@
             "example": {
                 "id": "33feeff2-5069-43fe-8853-428651e5be79",
                 "name": "example_name",
-                "updated_at ": "2021-04-28 13:12:46",
+                "updated_at": "2021-04-28 13:12:46",
                 "warning": {
                     "message": "Sample warning message"
                 },
@@ -33645,7 +33645,7 @@
                         "dynamic"
                     ]
                 },
-                "updated_at ": {
+                "updated_at": {
                     "type": "string",
                     "description": "The date and time that this transactional template version was updated.",
                     "pattern": "^(\\d{4}-\\d{2}-\\d{2}) ((\\d{2}):(\\d{2}):(\\d{2}))$"
@@ -33662,13 +33662,13 @@
                 "id",
                 "name",
                 "generation",
-                "updated_at "
+                "updated_at"
             ],
             "example": {
                 "id": "0c314114-a2b7-4523-8cbc-a293d7d19007",
                 "name": "example_name",
                 "generation": "legacy",
-                "updated_at ": "2021-04-28 13:12:46",
+                "updated_at": "2021-04-28 13:12:46",
                 "versions": []
             }
         },

--- a/oai_stoplight.json
+++ b/oai_stoplight.json
@@ -23204,7 +23204,7 @@
                                         "id": "fae7c985-eb92-4b47-9987-28ec29dbc698",
                                         "name": "example_name",
                                         "generation": "legacy",
-                                        "updated_at ": "2020-11-12 12:00:09",
+                                        "updated_at": "2020-11-12 12:00:09",
                                         "versions": []
                                     }
                                 ],
@@ -23297,7 +23297,7 @@
                                 "id": "733ba07f-ead1-41fc-933a-3976baa2371",
                                 "name": "example_name",
                                 "generation": "dynamic",
-                                "updated_at ": "2019-03-13T11:52:41.009Z",
+                                "updated_at": "2019-03-13T11:52:41.009Z",
                                 "versions": []
                             }
                         }
@@ -23332,7 +23332,7 @@
                                 "id": "40da60e6-66f3-4223-9406-ba58b7f55a62",
                                 "name": "Duis in dolor",
                                 "generation": "legacy",
-                                "updated_at ": "2020-12-12 58:26:65",
+                                "updated_at": "2020-12-12 58:26:65",
                                 "versions": []
                             }
                         }
@@ -32558,7 +32558,7 @@
             "example": {
                 "id": "33feeff2-5069-43fe-8853-428651e5be79",
                 "name": "example_name",
-                "updated_at ": "2021-04-28 13:12:46",
+                "updated_at": "2021-04-28 13:12:46",
                 "warning": {
                     "message": "Sample warning message"
                 },
@@ -33627,7 +33627,7 @@
                         "dynamic"
                     ]
                 },
-                "updated_at ": {
+                "updated_at": {
                     "type": "string",
                     "description": "The date and time that this transactional template version was updated.",
                     "pattern": "^(\\d{4}-\\d{2}-\\d{2}) ((\\d{2}):(\\d{2}):(\\d{2}))$"
@@ -33644,13 +33644,13 @@
                 "id",
                 "name",
                 "generation",
-                "updated_at "
+                "updated_at"
             ],
             "example": {
                 "id": "0c314114-a2b7-4523-8cbc-a293d7d19007",
                 "name": "example_name",
                 "generation": "legacy",
-                "updated_at ": "2021-04-28 13:12:46",
+                "updated_at": "2021-04-28 13:12:46",
                 "versions": []
             }
         },

--- a/oai_v3_stoplight.json
+++ b/oai_v3_stoplight.json
@@ -28400,7 +28400,7 @@
                                             "id": "733ba07f-ead1-41fc-933a-3976baa23716",
                                             "name": "example_name",
                                             "generation": "legacy",
-                                            "updated_at ": "2021-04-28 13:12:46",
+                                            "updated_at": "2021-04-28 13:12:46",
                                             "versions": []
                                         }
                                     }
@@ -28499,7 +28499,7 @@
                                                     "id": "fae7c985-eb92-4b47-9987-28ec29dbc698",
                                                     "name": "example_name",
                                                     "generation": "legacy",
-                                                    "updated_at ": "2020-11-12 12:00:09",
+                                                    "updated_at": "2020-11-12 12:00:09",
                                                     "versions": []
                                                 }
                                             ],
@@ -28615,7 +28615,7 @@
                                             "id": "733ba07f-ead1-41fc-933a-3976baa23716",
                                             "name": "example_name",
                                             "generation": "dynamic",
-                                            "updated_at ": "2020-12-12 58:26:65",
+                                            "updated_at": "2020-12-12 58:26:65",
                                             "versions": []
                                         }
                                     }
@@ -28665,7 +28665,7 @@
                                             "id": "40da60e6-66f3-4223-9406-ba58b7f55a62",
                                             "name": "Duis in dolor",
                                             "generation": "legacy",
-                                            "updated_at ": "2020-12-12 58:26:65",
+                                            "updated_at": "2020-12-12 58:26:65",
                                             "versions": []
                                         }
                                     }
@@ -28734,7 +28734,7 @@
                                             "id": "733ba07f-ead1-41fc-933a-3976baa23716",
                                             "name": "new_example_name",
                                             "generation": "legacy",
-                                            "updated_at ": "2021-04-28 13:12:46",
+                                            "updated_at": "2021-04-28 13:12:46",
                                             "versions": []
                                         }
                                     }
@@ -42289,7 +42289,7 @@
                 "example": {
                     "id": "33feeff2-5069-43fe-8853-428651e5be79",
                     "name": "example_name",
-                    "updated_at ": "2021-04-28 13:12:46",
+                    "updated_at": "2021-04-28 13:12:46",
                     "warning": {
                         "message": "Sample warning message"
                     },
@@ -43229,7 +43229,7 @@
                             "dynamic"
                         ]
                     },
-                    "updated_at ": {
+                    "updated_at": {
                         "type": "string",
                         "description": "The date and time that this transactional template version was updated.",
                         "pattern": "^(\\d{4}-\\d{2}-\\d{2}) ((\\d{2}):(\\d{2}):(\\d{2}))$"
@@ -43246,13 +43246,13 @@
                     "id",
                     "name",
                     "generation",
-                    "updated_at "
+                    "updated_at"
                 ],
                 "example": {
                     "id": "0c314114-a2b7-4523-8cbc-a293d7d19007",
                     "name": "example_name",
                     "generation": "legacy",
-                    "updated_at ": "2021-04-28 13:12:46",
+                    "updated_at": "2021-04-28 13:12:46",
                     "versions": []
                 },
                 "x-stoplight": {


### PR DESCRIPTION
Fix: Remove trailing whitespace from "updated_at " to make it "updated_at"

Fixes #107 

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-oai/blob/main/CONTRIBUTING.md) and my PR follows them
- [X] I have titled the PR appropriately
- [X] I have updated my branch with the main branch
- [N] I have added tests that prove my fix is effective or that my feature works
- [ N I have added the necessary documentation about the functionality in the appropriate .md file
- [N] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com), or create a GitHub Issue in this repository.
